### PR TITLE
include: uapi: Add support for 128x32 alignment of NV12

### DIFF
--- a/include/uapi/media/msm_media_info.h
+++ b/include/uapi/media/msm_media_info.h
@@ -53,6 +53,41 @@ enum color_fmts {
 	 *          + UV_Stride * UV_Scanlines, 4096)
 	 */
 	COLOR_FMT_NV12,
+	/* Venus NV12:
+	 * YUV 4:2:0 image with a plane of 8 bit Y samples followed
+	 * by an interleaved U/V plane containing 8 bit 2x2 subsampled
+	 * colour difference samples.
+	 *
+	 * <-------- Y/UV_Stride -------->
+	 * <------- Width ------->
+	 * Y Y Y Y Y Y Y Y Y Y Y Y . . . .  ^           ^
+	 * Y Y Y Y Y Y Y Y Y Y Y Y . . . .  |           |
+	 * Y Y Y Y Y Y Y Y Y Y Y Y . . . .  Height      |
+	 * Y Y Y Y Y Y Y Y Y Y Y Y . . . .  |          Y_Scanlines
+	 * Y Y Y Y Y Y Y Y Y Y Y Y . . . .  |           |
+	 * Y Y Y Y Y Y Y Y Y Y Y Y . . . .  |           |
+	 * Y Y Y Y Y Y Y Y Y Y Y Y . . . .  |           |
+	 * Y Y Y Y Y Y Y Y Y Y Y Y . . . .  V           |
+	 * . . . . . . . . . . . . . . . .              |
+	 * . . . . . . . . . . . . . . . .              |
+	 * . . . . . . . . . . . . . . . .              |
+	 * . . . . . . . . . . . . . . . .              V
+	 * U V U V U V U V U V U V . . . .  ^
+	 * U V U V U V U V U V U V . . . .  |
+	 * U V U V U V U V U V U V . . . .  |
+	 * U V U V U V U V U V U V . . . .  UV_Scanlines
+	 * . . . . . . . . . . . . . . . .  |
+	 * . . . . . . . . . . . . . . . .  V
+	 * . . . . . . . . . . . . . . . .  --> Buffer size alignment
+	 *
+	 * Y_Stride : Width aligned to 128
+	 * UV_Stride : Width aligned to 128
+	 * Y_Scanlines: Height aligned to 32
+	 * UV_Scanlines: Height/2 aligned to 16
+	 * Total size = align(Y_Stride * Y_Scanlines
+	 *          + UV_Stride * UV_Scanlines, 4096)
+	 */
+	COLOR_FMT_NV12_128,
 	/* Venus NV21:
 	 * YUV 4:2:0 image with a plane of 8 bit Y samples followed
 	 * by an interleaved V/U plane containing 8 bit 2x2 subsampled
@@ -786,6 +821,7 @@ static inline unsigned int VENUS_Y_STRIDE(unsigned int color_fmt,
 		alignment = 512;
 		stride = MSM_MEDIA_ALIGN(width, alignment);
 		break;
+	case COLOR_FMT_NV12_128:
 	case COLOR_FMT_NV12_UBWC:
 		alignment = 128;
 		stride = MSM_MEDIA_ALIGN(width, alignment);
@@ -829,6 +865,7 @@ static inline unsigned int VENUS_UV_STRIDE(unsigned int color_fmt,
 		alignment = 512;
 		stride = MSM_MEDIA_ALIGN(width, alignment);
 		break;
+	case COLOR_FMT_NV12_128:
 	case COLOR_FMT_NV12_UBWC:
 		alignment = 128;
 		stride = MSM_MEDIA_ALIGN(width, alignment);
@@ -871,6 +908,7 @@ static inline unsigned int VENUS_Y_SCANLINES(unsigned int color_fmt,
 	case COLOR_FMT_NV12_512:
 		alignment = 512;
 		break;
+	case COLOR_FMT_NV12_128:
 	case COLOR_FMT_NV12_UBWC:
 	case COLOR_FMT_P010:
 		alignment = 32;
@@ -908,6 +946,7 @@ static inline unsigned int VENUS_UV_SCANLINES(unsigned int color_fmt,
 	case COLOR_FMT_NV12_512:
 		alignment = 256;
 		break;
+	case COLOR_FMT_NV12_128:
 	case COLOR_FMT_NV12_BPP10_UBWC:
 	case COLOR_FMT_P010_UBWC:
 	case COLOR_FMT_P010:
@@ -1208,6 +1247,7 @@ static inline unsigned int VENUS_BUFFER_SIZE(unsigned int color_fmt,
 	case COLOR_FMT_NV12:
 	case COLOR_FMT_P010:
 	case COLOR_FMT_NV12_512:
+	case COLOR_FMT_NV12_128:
 		y_plane = y_stride * y_sclines;
 		uv_plane = uv_stride * uv_sclines;
 		size = y_plane + uv_plane;


### PR DESCRIPTION
Introduce new uapi color format
COLOR_FMT_NV12_128 to map with NV12 128x32
alignment.

Change-Id: Ic9f4dea15108d05a49d9abdcab24459746111fe5
Signed-off-by: Ankush Agarwalla <agarwall@codeaurora.org>